### PR TITLE
Cast Seconds to FloatField

### DIFF
--- a/pg_utils/utils.py
+++ b/pg_utils/utils.py
@@ -50,6 +50,12 @@ class Seconds(Func):
     function = 'EXTRACT'
     template = '%(function)s(EPOCH FROM %(expressions)s)'
 
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get('output_field'):
+            kwargs['output_field'] = FloatField()
+
+        return super(Seconds, self).__init__(*args, **kwargs)
+
 
 class DistinctSum(Sum):
     '''

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -69,3 +69,15 @@ class AuthorQueryExpressionTests(TestCase):
             duration=Seconds(F('modified_at') - F('created_at'))
         )
         self.assertEqual(queryset[0].duration, 5)
+
+    def test_cast_seconds_to_float(self):
+        current_time = timezone.now()
+        offset_time = current_time + timedelta(seconds=5)
+        Author.objects.create(name='test_name', modified_at=offset_time,
+                              created_at=current_time)
+
+        queryset = Author.objects \
+            .annotate(duration=Seconds(F('modified_at') - F('created_at'))) \
+            .filter(duration=5)
+
+        self.assertTrue(queryset.exists())


### PR DESCRIPTION
When I try to filter a Seconds field it raise error "TypeError: expected string or bytes-like object" , so we need to cast it to float. 

This PR change Seconds to set default output_field to FloatField.